### PR TITLE
Add option to development install to clone docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "axios": "^0.21.1",
                 "chalk": "^4.1.0",
                 "find-up": "^5.0.0",
+                "glob": "^7.1.6",
                 "gunzip-maybe": "^1.4.2",
                 "inquirer": "^8.0.0",
                 "isomorphic-git": "^1.8.1",
@@ -22,6 +23,7 @@
                 "nodecg-io": "index.js"
             },
             "devDependencies": {
+                "@types/glob": "^7.1.3",
                 "@types/gunzip-maybe": "^1.4.0",
                 "@types/inquirer": "^7.3.1",
                 "@types/jest": "^26.0.22",
@@ -1063,6 +1065,16 @@
                 "@babel/types": "^7.3.0"
             }
         },
+        "node_modules/@types/glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+            "dev": true,
+            "dependencies": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1709,8 +1721,7 @@
         "node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "node_modules/base": {
             "version": "0.11.2",
@@ -1764,7 +1775,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2173,8 +2183,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "node_modules/convert-source-map": {
             "version": "1.7.0",
@@ -3295,8 +3304,7 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -3384,7 +3392,6 @@
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
             "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -3713,7 +3720,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5297,7 +5303,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5779,7 +5784,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9230,6 +9234,16 @@
                 "@babel/types": "^7.3.0"
             }
         },
+        "@types/glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+            "dev": true,
+            "requires": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
         "@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -9763,8 +9777,7 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
             "version": "0.11.2",
@@ -9814,7 +9827,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10152,8 +10164,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "convert-source-map": {
             "version": "1.7.0",
@@ -11040,8 +11051,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "2.3.2",
@@ -11107,7 +11117,6 @@
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
             "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -11361,7 +11370,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -12611,7 +12619,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -12993,8 +13000,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-key": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "homepage": "https://github.com/codeoverflow-org/nodecg-io-cli#readme",
     "devDependencies": {
+        "@types/glob": "^7.1.3",
         "@types/gunzip-maybe": "^1.4.0",
         "@types/inquirer": "^7.3.1",
         "@types/jest": "^26.0.22",
@@ -55,6 +56,7 @@
         "axios": "^0.21.1",
         "chalk": "^4.1.0",
         "find-up": "^5.0.0",
+        "glob": "^7.1.6",
         "gunzip-maybe": "^1.4.2",
         "inquirer": "^8.0.0",
         "isomorphic-git": "^1.8.1",

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -61,12 +61,7 @@ async function install(concurrency: number): Promise<void> {
 
     // Get packages
     if (requestedInstall.dev) {
-        await createDevInstall(
-            requestedInstall,
-            currentInstall && currentInstall.dev ? currentInstall : undefined,
-            nodecgIODir,
-            concurrency,
-        );
+        await createDevInstall(requestedInstall, nodecgIODir, concurrency);
     } else {
         await createProductionInstall(
             requestedInstall,

--- a/src/installation.ts
+++ b/src/installation.ts
@@ -16,7 +16,6 @@ export interface DevelopmentInstallation {
     version: "development";
     useSamples: boolean;
     cloneDocs: boolean;
-    commitHash?: string;
 }
 
 /**

--- a/src/installation.ts
+++ b/src/installation.ts
@@ -15,6 +15,7 @@ export interface DevelopmentInstallation {
     dev: true;
     version: "development";
     useSamples: boolean;
+    cloneDocs: boolean;
     commitHash?: string;
 }
 

--- a/test/install/development.ts
+++ b/test/install/development.ts
@@ -2,12 +2,16 @@ import { vol } from "memfs";
 import * as git from "isomorphic-git";
 import * as fsUtils from "../../src/fsUtils";
 import { fsRoot, validDevInstall, nodecgIODir } from "../testUtils";
-import { createDevInstall, getGitRepo } from "../../src/install/development";
+import * as dev from "../../src/install/development";
 
 const defaultFetchResult: git.FetchResult = {
     defaultBranch: "master",
     fetchHead: "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
     fetchHeadDescription: "",
+};
+const altFetchResult: git.FetchResult = {
+    ...defaultFetchResult,
+    fetchHead: "e0c9035898dd52fc65c41454cec9c4d2611bfb37",
 };
 
 const cloneSpy = jest.spyOn(git, "clone").mockResolvedValue();
@@ -31,21 +35,13 @@ afterEach(() => {
 
 describe("createDevInstall", () => {
     test("should not do anything if HEAD commit hash didn't change", async () => {
-        await createDevInstall(validDevInstall, validDevInstall, fsRoot, 0);
+        await dev.createDevInstall(validDevInstall, fsRoot, 0);
         expect(execSpy).toHaveBeenCalledTimes(0);
     });
 
     test("should execute install, bootstrap and build", async () => {
-        await createDevInstall(
-            validDevInstall,
-            {
-                ...validDevInstall,
-                commitHash: "abc",
-            },
-            fsRoot,
-            0,
-        );
-
+        fetchSpy.mockResolvedValueOnce(altFetchResult);
+        await dev.createDevInstall(validDevInstall, fsRoot, 0);
         expect(execSpy).toHaveBeenCalledTimes(3);
     });
 
@@ -54,26 +50,23 @@ describe("createDevInstall", () => {
 
 describe("getGitRepo", () => {
     test("should clone repo if directory does not exists", async () => {
-        await getGitRepo(nodecgIODir, "nodecg-io");
+        await dev.getGitRepo(nodecgIODir, "nodecg-io");
         expect(cloneSpy).toHaveBeenCalled();
     });
 
     test("should fetch repo if directory does exist", async () => {
         await vol.promises.mkdir(nodecgIODir);
-        await getGitRepo(nodecgIODir, "nodecg-io");
+        await dev.getGitRepo(nodecgIODir, "nodecg-io");
         expect(fetchSpy).toHaveBeenCalled();
         expect(mergeSpy).toHaveBeenCalledTimes(0);
         expect(checkoutSpy).toHaveBeenCalledTimes(0);
     });
 
     test("should merge and checkout if new commits were fetched", async () => {
-        fetchSpy.mockResolvedValueOnce({
-            ...defaultFetchResult,
-            fetchHead: "e0c9035898dd52fc65c41454cec9c4d2611bfb37",
-        });
+        fetchSpy.mockResolvedValueOnce(altFetchResult);
 
         await vol.promises.mkdir(nodecgIODir);
-        await getGitRepo(nodecgIODir, "nodecg-io");
+        await dev.getGitRepo(nodecgIODir, "nodecg-io");
         expect(mergeSpy).toHaveBeenCalled();
         expect(checkoutSpy).toHaveBeenCalled();
     });

--- a/test/install/development.ts
+++ b/test/install/development.ts
@@ -38,17 +38,23 @@ describe("createDevInstall", () => {
 
         expect(execSpy).toHaveBeenCalledTimes(3);
     });
+
+    test.todo("should only clone docs if wanted in installation info");
 });
 
 describe("getGitRepo", () => {
     test("should clone repo if directory does not exists", async () => {
-        await getGitRepo(nodecgIODir);
+        await getGitRepo(nodecgIODir, "nodecg-io");
         expect(cloneSpy).toHaveBeenCalled();
     });
 
-    test("should pull repo if directory does exist", async () => {
+    // Temporarily disabled because pulling is not working properly right now
+    // refer to the comment in pullRepo for further details.
+    test.skip("should pull repo if directory does exist", async () => {
         await vol.promises.mkdir(nodecgIODir);
-        await getGitRepo(nodecgIODir);
+        await getGitRepo(nodecgIODir, "nodecg-io");
         expect(ffSpy).toHaveBeenCalled();
     });
+
+    test.todo("should use correct git url for nodecg-io and docs");
 });

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -40,6 +40,7 @@ export const validDevInstall: DevelopmentInstallation = {
     dev: true,
     version: "development",
     useSamples: false,
+    cloneDocs: false,
     commitHash: "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
 };
 export const validProdInstall: ProductionInstallation = {

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -41,7 +41,6 @@ export const validDevInstall: DevelopmentInstallation = {
     version: "development",
     useSamples: false,
     cloneDocs: false,
-    commitHash: "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
 };
 export const validProdInstall: ProductionInstallation = {
     dev: false,


### PR DESCRIPTION
Add option to optionally clone the nodecg-io-docs repo for developer convenience. 
Currently pulling is broken because for some reason isomorphic-git sometimes walks `node_modules` and all symlinks created by lerna which would take ages. Still investigating what causes this...