### PR TITLE
Redownload dashboard when upgrading core

### DIFF
--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -10,8 +10,6 @@ import * as os from "os";
 import { logger } from "../log";
 import { requireNpmV7 } from "../npm";
 
-// TODO: remove nodecg-io directory if initial installation was aborted?
-
 export const installModule: CommandModule<unknown, { concurrency: number }> = {
     command: "install",
     describe: "installs nodecg-io to your local nodecg installation",

--- a/src/install/prompt.ts
+++ b/src/install/prompt.ts
@@ -151,7 +151,7 @@ function getPackagePath(pkgName: string) {
 async function getPackageVersion(pkgName: string, minorVersion: string) {
     const version = await getHighestPatchVersion(pkgName, minorVersion);
     // if patch part could be found out we will use .0 as it should always exist if the minor version also does.
-    return version ?? `${version}.0`;
+    return version ?? `${minorVersion}.0`;
 }
 
 function getPackageSymlinks(pkgName: string) {

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -192,6 +192,16 @@ export async function removeNpmPackage(pkg: NpmPackage, nodecgIODir: string): Pr
 }
 
 /**
+ * Returns you all packages that are in a sub-path of rootPkg.
+ * This is helpful if you have reinstalled rootPkg and now also need to reinstall all packages
+ * that were in the directory of rootPkg because they also got removed in {@link removeNpmPackage}.
+ * @returns the packages that are contained in rootPkg
+ */
+export function getSubPackages(allPackages: NpmPackage[], rootPkg: NpmPackage): NpmPackage[] {
+    return allPackages.filter((pkg) => pkg !== rootPkg && pkg.path.startsWith(rootPkg.path));
+}
+
+/**
  * Gets version of the installed npm by running "npm --version".
  * @returns the npm version or undefined if npm is not installed/not in $PATH.
  */

--- a/test/install/production.ts
+++ b/test/install/production.ts
@@ -1,6 +1,6 @@
 import { vol } from "memfs";
 import * as path from "path";
-import { corePkg, nodecgIODir, twitchChatPkg, validProdInstall } from "../testUtils";
+import { corePkg, dashboardPkg, nodecgIODir, twitchChatPkg, validProdInstall } from "../testUtils";
 import { diffPackages, installPackages, removePackages, validateInstall } from "../../src/install/production";
 import * as installation from "../../src/installation";
 import * as fsUtils from "../../src/fsUtils";
@@ -44,6 +44,13 @@ describe("diffPackages", () => {
         const { pkgInstall, pkgRemove } = diffPackages([twitchChatPkg, corePkg], [twitchChatPkg, corePkg]);
         expect(pkgRemove).toStrictEqual([]);
         expect(pkgInstall).toStrictEqual([]);
+    });
+
+    test("should install dashboard (sub pkg) if upgrading core", async () => {
+        // dashboard not modified, but should still be installed because it is in core and core gets upgraded
+        const { pkgInstall, pkgRemove } = diffPackages([corePkg2, dashboardPkg], [corePkg, dashboardPkg]);
+        expect(pkgRemove).toStrictEqual([corePkg]);
+        expect(pkgInstall).toStrictEqual([corePkg2, dashboardPkg]);
     });
 });
 

--- a/test/install/prompt.ts
+++ b/test/install/prompt.ts
@@ -25,7 +25,7 @@ describe("getCompatibleVersions", () => {
 });
 
 describe("buildPackageList", () => {
-    const ver = "0.1.0";
+    const ver = "0.1";
     const testSvcName = "testSvc";
     const testSvcPkgName = `nodecg-io-${testSvcName}`;
     const mock = jest.spyOn(npm, "getHighestPatchVersion").mockResolvedValue("0.1.1");

--- a/test/npm/pkgManagement.ts
+++ b/test/npm/pkgManagement.ts
@@ -1,6 +1,6 @@
 import { createFsFromVolume, vol } from "memfs";
-import { createNpmSymlinks, removeNpmPackage, runNpmInstall } from "../../src/npm";
-import { tempDir, corePkg, fsRoot } from "../testUtils";
+import { createNpmSymlinks, getSubPackages, removeNpmPackage, runNpmInstall } from "../../src/npm";
+import { tempDir, corePkg, fsRoot, twitchChatPkg, dashboardPkg } from "../testUtils";
 import * as fsUtils from "../../src/fsUtils";
 import * as path from "path";
 
@@ -43,5 +43,15 @@ describe("removeNpmPackage", () => {
         const spy = jest.spyOn(fsUtils, "removeDirectory").mockResolvedValue();
         await removeNpmPackage(corePkg, await tempDir());
         expect(spy).toHaveBeenCalled();
+    });
+});
+
+describe("getSubPackages", () => {
+    test("should return empty list if no packages are inside the passed package", async () => {
+        expect(getSubPackages([corePkg, twitchChatPkg], corePkg)).toStrictEqual([]);
+    });
+
+    test("should return dashboard to be inside core", async () => {
+        expect(getSubPackages([corePkg, dashboardPkg], corePkg)).toStrictEqual([dashboardPkg]);
     });
 });

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,5 +1,5 @@
 import * as temp from "temp";
-import { corePackage } from "../src/install/nodecgIOVersions";
+import { corePackage, dashboardPackage, dashboardPath } from "../src/install/nodecgIOVersions";
 import * as path from "path";
 import { DevelopmentInstallation, ProductionInstallation } from "../src/installation";
 
@@ -19,6 +19,11 @@ export const corePkg = {
 export const twitchChatPkg = {
     name: "nodecg-io-twitch-chat",
     path: "nodecg-io-twitch-chat",
+    version: "0.1.0",
+};
+export const dashboardPkg = {
+    name: dashboardPackage,
+    path: dashboardPath,
     version: "0.1.0",
 };
 export const nodecgExampleConfig = {


### PR DESCRIPTION
When upgrading core the `nodecg-io-core` directory will be deleted and with it the dashboard in `nodecg-io-core/dashboard`. When reinstalling core the dashboard wouldn't get redownloaded and would be missing from the install. This PR fixes this by redownloading any packages that are inside the path of upgraded packages. 