### PR TITLE
fix: build typescript in prepublish scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-      - name: Build
-        run: npm run build
 
       - name: Release
         env:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "format": "prettier --write \"./**/*.{ts,json,md,js}\"",
         "format-pre-commit": "pretty-quick --staged --pattern '*/**/*.{ts,json,md,js}'",
         "prepare": "husky install",
-        "semantic-release": "semantic-release"
+        "semantic-release": "semantic-release",
+        "prepublish": "npm run build"
     },
     "bin": {
         "nodecg-io": "index.js"


### PR DESCRIPTION
This fixes the problem that the cli gets built before semantic-releaser updates the version. Because of this the released `0.1.0` shows `0.0.1` when running `nodecg-io --version` because it was built with that version which copies the `package.json` into the `build` directory. Then semantic-release updates the version and the copied `package.json` isn't updated.

With this change we don't build the cli in a ci step anymore, but with the npm `prepublish` hook. That way semantic-release will bump the version and run `npm publish` which will then build the cli with the update version.