### PR TITLE
fix: build ts in prepublishOnly instead of prepublish because npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "format-pre-commit": "pretty-quick --staged --pattern '*/**/*.{ts,json,md,js}'",
         "prepare": "husky install",
         "semantic-release": "semantic-release",
-        "prepublish": "npm run build"
+        "prepublishOnly": "npm run build"
     },
     "bin": {
         "nodecg-io": "index.js"


### PR DESCRIPTION
Follow up on #12

`prepublish` does not run on `npm publish` KEKW, only `prepublishOnly` does. Brilliant naming!