### PR TITLE
fix(generate): add missinig newlines between generated requireService calls

### DIFF
--- a/src/generate/extension.ts
+++ b/src/generate/extension.ts
@@ -97,7 +97,7 @@ function genRequireServiceCall(writer: CodeBlockWriter, svc: ServiceNames, lang:
         writer.write(`<${svc.clientName}>`);
     }
 
-    writer.write(`(nodecg, `).quote(svc.name).write(");");
+    writer.write(`(nodecg, `).quote(svc.name).write(");\n");
 }
 
 function genOnAvailableCall(writer: CodeBlockWriter, svc: ServiceNames) {


### PR DESCRIPTION
I forgot the newline after each generated `requireService` calls. Because of this if you selected multiple versions all the `requireService` calls would be in a single line, one after another. This PR fixes that by writing a newline after each call.