### PR TITLE
fix(install): fix incorrect concurrency option when creating a dev install

### DIFF
--- a/src/install/development.ts
+++ b/src/install/development.ts
@@ -185,6 +185,6 @@ async function installNPMDependencies(nodecgIODir: string) {
 
 async function buildTypeScript(nodecgIODir: string, concurrency: number) {
     logger.info("Compiling nodecg-io...");
-    await runNpmBuild(nodecgIODir, "--", "concurrency", concurrency.toString());
+    await runNpmBuild(nodecgIODir, "--", "--concurrency", concurrency.toString());
     logger.success("Compiled nodecg-io.");
 }


### PR DESCRIPTION
Creating a development install would result in an error because the dashes of the concurrency option that is passed through npm to lerna was missing the two dashes.
This bug was introduced in a refactoring in a593c421d128eb469d8ecea53e37be47fcf86c46.