### PR TITLE
Add dependabot to update GH Actions and npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
Enables dependabot as described in https://github.com/codeoverflow-org/nodecg-io/issues/263 and #17 