### PR TITLE
feat(generate): use nodecg-types in generated bundles

### DIFF
--- a/src/generate/extension.ts
+++ b/src/generate/extension.ts
@@ -42,7 +42,7 @@ export async function genExtension(opts: GenerationOptions, install: ProductionI
     genImport(writer, "requireService", opts.corePackage.name, opts.language);
 
     if (opts.language === "typescript") {
-        genImport(writer, "NodeCG", "nodecg/types/server", opts.language);
+        genImport(writer, "NodeCG", "nodecg-types/types/server", opts.language);
         // Service import statements
         services.forEach((svc) => {
             genImport(writer, svc.clientName, svc.packageName, opts.language);

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -29,7 +29,7 @@ export const generateModule: CommandModule = {
 
             const opts = await promptGenerationOpts(nodecgDir, install);
 
-            await generateBundle(nodecgDir, opts, install);
+            await generateBundle(opts, install);
 
             logger.success(`Successfully generated bundle ${opts.bundleName}.`);
         } catch (e) {
@@ -63,11 +63,7 @@ export function ensureValidInstallation(install: Installation | undefined): inst
     return true;
 }
 
-export async function generateBundle(
-    nodecgDir: string,
-    opts: GenerationOptions,
-    install: ProductionInstallation,
-): Promise<void> {
+export async function generateBundle(opts: GenerationOptions, install: ProductionInstallation): Promise<void> {
     // Create dir if necessary
     if (!(await directoryExists(opts.bundlePath))) {
         await fs.promises.mkdir(opts.bundlePath);
@@ -84,7 +80,7 @@ export async function generateBundle(
     }
 
     // All of these calls only generate files if they are set accordingly in the GenerationOptions
-    await genPackageJson(nodecgDir, opts);
+    await genPackageJson(opts);
     await genTsConfig(opts);
     await genGitIgnore(opts);
     await genExtension(opts, install);

--- a/test/generate/index.ts
+++ b/test/generate/index.ts
@@ -1,13 +1,5 @@
 import { vol } from "memfs";
-import {
-    corePkg,
-    fsRoot,
-    nodecgPackageJson,
-    nodecgPackageJsonStr,
-    twitchChatPkg,
-    validDevInstall,
-    validProdInstall,
-} from "../test.util";
+import { corePkg, fsRoot, nodecgPackageJsonStr, twitchChatPkg, validDevInstall, validProdInstall } from "../test.util";
 import { SemVer } from "semver";
 import * as path from "path";
 import * as installation from "../../src/utils/installation";
@@ -56,14 +48,14 @@ describe("generateBundle", () => {
     test("should fail if bundle directory already contains files", async () => {
         // Create some file inside the directory in which the bundle would be generated.
         await vol.promises.writeFile(packageJsonPath, "");
-        await expect(generateBundle(fsRoot, defaultOpts, validProdInstall)).rejects.toThrow(
+        await expect(generateBundle(defaultOpts, validProdInstall)).rejects.toThrow(
             "already exists and contains files",
         );
     });
 
     test("should install dependencies", async () => {
         const installMock = jest.spyOn(npm, "runNpmInstall").mockResolvedValue();
-        await generateBundle(fsRoot, defaultOpts, validProdInstall);
+        await generateBundle(defaultOpts, validProdInstall);
 
         expect(installMock).toHaveBeenCalled();
         expect(installMock).toHaveBeenCalledWith(defaultOpts.bundlePath, false);
@@ -71,14 +63,14 @@ describe("generateBundle", () => {
 
     test("should run build if typescript", async () => {
         const buildMock = jest.spyOn(npm, "runNpmBuild").mockClear().mockResolvedValue();
-        await generateBundle(fsRoot, defaultOpts, validProdInstall);
+        await generateBundle(defaultOpts, validProdInstall);
         expect(buildMock).toHaveBeenCalledTimes(1);
         expect(buildMock).toHaveBeenCalledWith(defaultOpts.bundlePath);
     });
 
     test("should not run build if javascript", async () => {
         const buildMock = jest.spyOn(npm, "runNpmBuild").mockClear().mockResolvedValue();
-        await generateBundle(fsRoot, jsOpts, validProdInstall);
+        await generateBundle(jsOpts, validProdInstall);
         expect(buildMock).toHaveBeenCalledTimes(0);
     });
 });
@@ -87,7 +79,7 @@ describe("genPackageJson", () => {
     // We don't have a good type for a package.json and this is only testing code so this should be fine.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async function genPackageJSON(opts: GenerationOptions = defaultOpts): Promise<any> {
-        await generateBundle(fsRoot, opts, validProdInstall);
+        await generateBundle(opts, validProdInstall);
         const packageJsonStr = await vol.promises.readFile(packageJsonPath);
         if (!packageJsonStr) throw new Error("package.json does not exist");
         return JSON.parse(packageJsonStr.toString());
@@ -112,12 +104,12 @@ describe("genPackageJson", () => {
     test("should have all required typing packages as dependency if typescript", async () => {
         const deps = (await genPackageJSON(defaultOpts))["dependencies"];
         const e = Object.entries(deps);
-        expect(e).toEqual(expect.arrayContaining([["nodecg", `^${nodecgPackageJson.version}`]]));
         expect(e).toEqual(expect.arrayContaining([[twitchChatPkg.name, `^${twitchChatPkg.version}`]]));
 
         // These dependencies should always have the latest version which is fetched by the mocked getLatestPackageVersion
         expect(e).toEqual(expect.arrayContaining([["typescript", `^1.2.3`]]));
         expect(e).toEqual(expect.arrayContaining([["@types/node", `^1.2.3`]]));
+        expect(e).toEqual(expect.arrayContaining([["nodecg-types", `^1.2.3`]]));
     });
 
     test("should have build scripts if typescript", async () => {


### PR DESCRIPTION
Refer to https://github.com/codeoverflow-org/nodecg-io/issues/239 for more information about `nodecg-types`. This PR updates the generation logic to generate bundles depending on `nodecg-types` instead of `nodecg` for typings when generating a TypeScript bundle.