### PR TITLE
Use zlib of node.js instead of gunzip-maybe to extract npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
                 "code-block-writer": "^11.0.0",
                 "find-up": "^5.0.0",
                 "glob": "^7.2.0",
-                "gunzip-maybe": "^1.4.2",
                 "inquirer": "^8.2.0",
                 "isomorphic-git": "^1.10.1",
                 "semver": "^7.3.5",
@@ -27,7 +26,6 @@
             "devDependencies": {
                 "@semantic-release/git": "^10.0.0",
                 "@types/glob": "^7.1.4",
-                "@types/gunzip-maybe": "^1.4.0",
                 "@types/inquirer": "^8.1.3",
                 "@types/jest": "^27.0.2",
                 "@types/node": "^16.10.3",
@@ -1480,15 +1478,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/gunzip-maybe": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@types/gunzip-maybe/-/gunzip-maybe-1.4.0.tgz",
-            "integrity": "sha512-dFP9GrYAR9KhsjTkWJ8q8Gsfql75YIKcg9DuQOj/IrlPzR7W+1zX+cclw1McV82UXAQ+Lpufvgk3e9bC8+HzgA==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/inquirer": {
             "version": "8.1.3",
             "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.1.3.tgz",
@@ -2217,14 +2206,6 @@
             "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
             "dev": true
         },
-        "node_modules/browserify-zlib": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-            "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-            "dependencies": {
-                "pako": "~0.2.0"
-            }
-        },
         "node_modules/browserslist": {
             "version": "4.17.3",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
@@ -2295,7 +2276,8 @@
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -2669,7 +2651,8 @@
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
         },
         "node_modules/cosmiconfig": {
             "version": "7.0.1",
@@ -3036,39 +3019,6 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/duplexify": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-            "dependencies": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
-            }
-        },
-        "node_modules/duplexify/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/duplexify/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -4043,22 +3993,6 @@
             "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
             "dev": true
         },
-        "node_modules/gunzip-maybe": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz",
-            "integrity": "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==",
-            "dependencies": {
-                "browserify-zlib": "^0.1.4",
-                "is-deflate": "^1.0.0",
-                "is-gzip": "^1.0.0",
-                "peek-stream": "^1.1.0",
-                "pumpify": "^1.3.3",
-                "through2": "^2.0.3"
-            },
-            "bin": {
-                "gunzip-maybe": "bin.js"
-            }
-        },
         "node_modules/handlebars": {
             "version": "4.7.7",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -4377,11 +4311,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-deflate": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
-            "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4416,14 +4345,6 @@
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-gzip": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-            "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4540,7 +4461,8 @@
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -9233,11 +9155,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/pako": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-            "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
-        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9312,16 +9229,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/peek-stream": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
-            "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "duplexify": "^3.5.0",
-                "through2": "^2.0.3"
             }
         },
         "node_modules/picocolors": {
@@ -9713,7 +9620,8 @@
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "node_modules/progress": {
             "version": "2.0.3",
@@ -9742,25 +9650,6 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
             "dev": true
-        },
-        "node_modules/pump": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
-        "node_modules/pumpify": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-            "dependencies": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
-            }
         },
         "node_modules/punycode": {
             "version": "2.1.1",
@@ -10638,11 +10527,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/stream-shift": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-        },
         "node_modules/string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -10939,6 +10823,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
             "dependencies": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
@@ -10948,6 +10833,7 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -10962,6 +10848,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -11450,6 +11337,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4"
             }
@@ -12664,15 +12552,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/gunzip-maybe": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@types/gunzip-maybe/-/gunzip-maybe-1.4.0.tgz",
-            "integrity": "sha512-dFP9GrYAR9KhsjTkWJ8q8Gsfql75YIKcg9DuQOj/IrlPzR7W+1zX+cclw1McV82UXAQ+Lpufvgk3e9bC8+HzgA==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
         "@types/inquirer": {
             "version": "8.1.3",
             "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.1.3.tgz",
@@ -13229,14 +13108,6 @@
             "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
             "dev": true
         },
-        "browserify-zlib": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-            "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-            "requires": {
-                "pako": "~0.2.0"
-            }
-        },
         "browserslist": {
             "version": "4.17.3",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
@@ -13280,7 +13151,8 @@
         "buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
         },
         "callsites": {
             "version": "3.1.0",
@@ -13575,7 +13447,8 @@
         "core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
         },
         "cosmiconfig": {
             "version": "7.0.1",
@@ -13864,41 +13737,6 @@
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
-            }
-        },
-        "duplexify": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-            "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -14642,19 +14480,6 @@
             "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
             "dev": true
         },
-        "gunzip-maybe": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz",
-            "integrity": "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==",
-            "requires": {
-                "browserify-zlib": "^0.1.4",
-                "is-deflate": "^1.0.0",
-                "is-gzip": "^1.0.0",
-                "peek-stream": "^1.1.0",
-                "pumpify": "^1.3.3",
-                "through2": "^2.0.3"
-            }
-        },
         "handlebars": {
             "version": "4.7.7",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -14873,11 +14698,6 @@
                 "has": "^1.0.3"
             }
         },
-        "is-deflate": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
-            "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
-        },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -14903,11 +14723,6 @@
             "requires": {
                 "is-extglob": "^2.1.1"
             }
-        },
-        "is-gzip": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-            "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
         },
         "is-interactive": {
             "version": "1.0.0",
@@ -14985,7 +14800,8 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -18462,11 +18278,6 @@
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
-        "pako": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-            "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
-        },
         "parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -18521,16 +18332,6 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
-        },
-        "peek-stream": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
-            "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
-            "requires": {
-                "buffer-from": "^1.0.0",
-                "duplexify": "^3.5.0",
-                "through2": "^2.0.3"
-            }
         },
         "picocolors": {
             "version": "0.2.1",
@@ -18812,7 +18613,8 @@
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "progress": {
             "version": "2.0.3",
@@ -18835,25 +18637,6 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
             "dev": true
-        },
-        "pump": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
-        "pumpify": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-            "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
-            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -19525,11 +19308,6 @@
                 }
             }
         },
-        "stream-shift": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-        },
         "string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -19754,6 +19532,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
             "requires": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
@@ -19763,6 +19542,7 @@
                     "version": "2.3.7",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -19777,6 +19557,7 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -20146,7 +19927,8 @@
         "xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true
         },
         "y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "devDependencies": {
         "@semantic-release/git": "^10.0.0",
         "@types/glob": "^7.1.4",
-        "@types/gunzip-maybe": "^1.4.0",
         "@types/inquirer": "^8.1.3",
         "@types/jest": "^27.0.2",
         "@types/node": "^16.10.3",
@@ -66,7 +65,6 @@
         "code-block-writer": "^11.0.0",
         "find-up": "^5.0.0",
         "glob": "^7.2.0",
-        "gunzip-maybe": "^1.4.2",
         "inquirer": "^8.2.0",
         "isomorphic-git": "^1.10.1",
         "semver": "^7.3.5",

--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { executeCommand, removeDirectory } from "./fs";
 import { exec } from "child_process";
 import { maxSatisfying, satisfies, SemVer } from "semver";
-import gunzip = require("gunzip-maybe");
+import * as zlib from "zlib";
 import * as tar from "tar-fs";
 
 const npmRegistryEndpoint = "https://registry.npmjs.org/";
@@ -144,7 +144,7 @@ export async function extractNpmPackageTar(
     tarStream: fs.ReadStream,
     nodecgIODir: string,
 ): Promise<void> {
-    const extractStream = tarStream.pipe(gunzip(3)).pipe(
+    const extractStream = tarStream.pipe(zlib.createGunzip({ level: 3 })).pipe(
         tar.extract(buildNpmPackagePath(pkg, nodecgIODir), {
             map: (header) => {
                 // Content inside the tar is in /package/*, so we need to rewrite the name to not create a directory


### PR DESCRIPTION
Instead of using the external `gunzip-maybe` dependency for extracting the gzipped npm packages we can use `zlib` which is integrated in node.js and we have one less dependency.