### PR TITLE
Implement function to find the nodecg installation by ourselfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
         "axios": "^0.24.0",
         "chalk": "^4.1.2",
         "code-block-writer": "^11.0.0",
-        "find-up": "^5.0.0",
         "glob": "^7.2.0",
         "gunzip-maybe": "^1.4.2",
         "inquirer": "^8.2.0",

--- a/src/utils/nodecgInstallation.ts
+++ b/src/utils/nodecgInstallation.ts
@@ -1,4 +1,3 @@
-import * as findUp from "find-up";
 import * as path from "path";
 import * as fs from "fs";
 import { SemVer } from "semver";
@@ -7,17 +6,21 @@ import { directoryExists } from "./fs";
 /**
  * Traverses the filesystem and uses {@link isNodeCGDirectory} to find a local nodecg installation.
  */
-export async function findNodeCGDirectory(cwd = process.cwd()): Promise<string> {
-    const res = await findUp(async (dir) => ((await isNodeCGDirectory(dir)) ? dir : undefined), {
-        type: "directory",
-        cwd,
-    });
-    if (res === undefined) {
+export async function findNodeCGDirectory(dir = process.cwd()): Promise<string> {
+    if (await isNodeCGDirectory(dir)) {
+        return dir;
+    }
+
+    const parent = path.dirname(dir);
+
+    // We're at the filesystem root because we cannot go one level up more and didn't found a nodecg installation
+    if (parent === dir) {
         throw new Error(
             "Couldn't find a nodecg installation. Make sure that you are in the directory of your nodecg installation.",
         );
     }
-    return res;
+
+    return findNodeCGDirectory(parent);
 }
 
 /**


### PR DESCRIPTION
Currently we're using [find-up](https://www.npmjs.com/package/find-up) to traverse the filesystem and find the nodecg installation if the user is an subdirectory like `bundles/`.
To reduce our dependencies we can simply implement this ourselfs. I can't remember why I used `find-up` in the first place as using it is almost harder than implementing it directly, lol.