### PR TITLE
fix(generate): use tsconfig from shared nodecg-io-tsconfig package

### DIFF
--- a/src/generate/extension.ts
+++ b/src/generate/extension.ts
@@ -45,7 +45,7 @@ export async function genExtension(opts: GenerationOptions, install: Installatio
     genImport(writer, "requireService", opts.corePackage.name, opts.language);
 
     if (opts.language === "typescript") {
-        genImport(writer, "NodeCG", `${opts.nodeeCGTypingsPackage}/types/server`, opts.language);
+        genImport(writer, "NodeCG", `${opts.nodeCGTypingsPackage}/types/server`, opts.language);
         // Service import statements
         services.forEach((svc) => {
             genImport(writer, svc.clientName, svc.packageName, opts.language);

--- a/src/generate/packageJson.ts
+++ b/src/generate/packageJson.ts
@@ -69,16 +69,20 @@ async function genDependencies(opts: GenerationOptions, serviceDeps: Dependency[
  * @param nodecgDir the directory in which nodecg is installed. Used to get nodecg version which will be used by nodecg dependency.
  */
 async function genTypeScriptDependencies(opts: GenerationOptions): Promise<Dependency[]> {
-    logger.debug(`Fetching latest ${opts.nodeeCGTypingsPackage}, typescript and @types/node versions...`);
-    const [nodecgVersion, latestNodeTypes, latestTypeScript] = await Promise.all([
+    logger.debug(
+        `Fetching latest ${opts.nodeeCGTypingsPackage}, nodecg-io-tsconfig, typescript and @types/node versions...`,
+    );
+    const [nodecgVersion, latestTsConfig, latestTypeScript, latestNodeTypes] = await Promise.all([
         getLatestPackageVersion(opts.nodeeCGTypingsPackage),
-        getLatestPackageVersion("@types/node"),
+        getLatestPackageVersion("nodecg-io-tsconfig"),
         getLatestPackageVersion("typescript"),
+        getLatestPackageVersion("@types/node"),
     ]);
 
     return [
-        [opts.nodeeCGTypingsPackage, `^${nodecgVersion}`],
         ["@types/node", `^${latestNodeTypes}`],
+        [opts.nodeeCGTypingsPackage, `^${nodecgVersion}`],
+        ["nodecg-io-tsconfig", `^${latestTsConfig}`],
         ["typescript", `^${latestTypeScript}`],
     ];
 }
@@ -90,7 +94,7 @@ async function genTypeScriptDependencies(opts: GenerationOptions): Promise<Depen
  */
 function genScripts(opts: GenerationOptions) {
     if (opts.language !== "typescript") {
-        // For JS we don't need any scripts to build anythiing.
+        // For JS we don't need any scripts to build anything.
         return undefined;
     }
 

--- a/src/generate/packageJson.ts
+++ b/src/generate/packageJson.ts
@@ -70,10 +70,10 @@ async function genDependencies(opts: GenerationOptions, serviceDeps: Dependency[
  */
 async function genTypeScriptDependencies(opts: GenerationOptions): Promise<Dependency[]> {
     logger.debug(
-        `Fetching latest ${opts.nodeeCGTypingsPackage}, nodecg-io-tsconfig, typescript and @types/node versions...`,
+        `Fetching latest ${opts.nodeCGTypingsPackage}, nodecg-io-tsconfig, typescript and @types/node versions...`,
     );
     const [nodecgVersion, latestTsConfig, latestTypeScript, latestNodeTypes] = await Promise.all([
-        getLatestPackageVersion(opts.nodeeCGTypingsPackage),
+        getLatestPackageVersion(opts.nodeCGTypingsPackage),
         getLatestPackageVersion("nodecg-io-tsconfig"),
         getLatestPackageVersion("typescript"),
         getLatestPackageVersion("@types/node"),
@@ -81,7 +81,7 @@ async function genTypeScriptDependencies(opts: GenerationOptions): Promise<Depen
 
     return [
         ["@types/node", `^${latestNodeTypes}`],
-        [opts.nodeeCGTypingsPackage, `^${nodecgVersion}`],
+        [opts.nodeCGTypingsPackage, `^${nodecgVersion}`],
         ["nodecg-io-tsconfig", `^${latestTsConfig}`],
         ["typescript", `^${latestTypeScript}`],
     ];

--- a/src/generate/prompt.ts
+++ b/src/generate/prompt.ts
@@ -29,7 +29,7 @@ export interface PromptedGenerationOptions {
 export interface GenerationOptions extends PromptedGenerationOptions {
     servicePackages: NpmPackage[];
     corePackage: NpmPackage;
-    nodeeCGTypingsPackage: "nodecg" | "nodecg-types";
+    nodeCGTypingsPackage: "nodecg" | "nodecg-types";
     bundlePath: string;
 }
 
@@ -178,6 +178,6 @@ export function computeGenOptsFields(
             return svcPackage;
         }),
         bundlePath: path.join(opts.bundleDir, opts.bundleName),
-        nodeeCGTypingsPackage: install.version === "0.1" ? "nodecg" : "nodecg-types",
+        nodeCGTypingsPackage: install.version === "0.1" ? "nodecg" : "nodecg-types",
     };
 }

--- a/src/generate/tsConfig.ts
+++ b/src/generate/tsConfig.ts
@@ -1,30 +1,18 @@
 import { GenerationOptions } from "./prompt";
 import { writeBundleFile } from "./utils";
 
-const defaultTsConfigJson = {
-    compilerOptions: {
-        target: "es2019",
-        sourceMap: true,
-        lib: ["es2019"],
-        alwaysStrict: true,
-        forceConsistentCasingInFileNames: true,
-        noFallthroughCasesInSwitch: true,
-        noImplicitAny: true,
-        noImplicitReturns: true,
-        noImplicitThis: true,
-        strictNullChecks: true,
-        skipLibCheck: true,
-        module: "CommonJS",
-        types: ["node"],
-    },
-};
-
 /**
  * Generates a tsconfig.json for a bundle if the language was set to typescript.
  */
 export async function genTsConfig(opts: GenerationOptions): Promise<void> {
     // Only TS needs its tsconfig.json compiler configuration
     if (opts.language === "typescript") {
-        await writeBundleFile(defaultTsConfigJson, opts.bundlePath, "tsconfig.json");
+        await writeBundleFile(
+            {
+                extends: "nodecg-io-tsconfig",
+            },
+            opts.bundlePath,
+            "tsconfig.json",
+        );
     }
 }


### PR DESCRIPTION
Lets the tsconfig that is generated by `nodecg-io generate` extend the `nodecg-io-tsconfig` package instead of writing a whole config each time.
This is for https://github.com/codeoverflow-org/nodecg-io/issues/362 / https://github.com/codeoverflow-org/nodecg-io/pull/395.