### PR TITLE
Add node.js v17 to CI buid matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [12, 14, 16]
+        node: [12, 14, 16, 17]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Ensures that the tests pass on the newest version of node.js too, as many use the latest current version and not the latest LTS version.