### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,3 +23,38 @@ jobs:
 
     - name: Run tests
       run: npm run test
+
+  integration_test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        version: ['0.1', '0.2', 'development']
+        node: [14, 16]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with: 
+        node-version: ${{ matrix.node }}
+
+    - name: Install system dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt update && sudo apt-get -y install libusb-1.0-0-dev libasound2-dev libudev-dev
+
+    - name: Upgrade npm
+      run: npm i -g npm
+
+    - name: Install node native development files
+      shell: bash
+      run: npx node-gyp install
+
+    - name: Install nodejs dependencies
+      run: npm ci
+
+    - name: Build
+      run: npm run build && npm link
+
+    - name: Run integration test
+      shell: bash
+      run: ./integration_test.sh ${{ matrix.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         node: [12, 14, 16]
@@ -26,6 +27,7 @@ jobs:
 
   integration_test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         version: ['0.1', '0.2', 'development']
@@ -43,7 +45,7 @@ jobs:
       run: sudo apt update && sudo apt-get -y install libusb-1.0-0-dev libasound2-dev libudev-dev
 
     - name: Upgrade npm
-      run: npm i -g npm
+      run: npm i -g npm@8.3.1
 
     - name: Install node native development files
       shell: bash

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -27,7 +27,14 @@ git clone https://github.com/nodecg/nodecg.git --depth 1 .
 if [ "$version" == "development" ]; then
     nodecg-io install --nodecg-io-version $version --docs
 else
+    # Install nodecg-io
     nodecg-io install --nodecg-io-version $version --all-services
+
+    # Generate a bundle that uses all available services
+    input="test\\n\n\\n\\na\\n\\n\\n\\n"
+    # We add a sleep of 500ms between each line so that stdin pauses and inquirer 
+    # thinks the user is done, reads and processes the input instead of assuming multi-line input.
+    echo -en "$input" | while read -r line; do echo "$line"; sleep 1; done | nodecg-io generate
 fi
 
 nodecg-io uninstall

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This is a very basic integration test that ensures that the nodecg-io cli can be used
+# to install nodecg-io to a NodeCG installation and (if a production installation is used)
+# succesfully generate a new bundle.
+# This is cun in a matrix in CI to ensure that it works for windows and ubuntu
+# and with all supported nodecg-io versions.
+set -e
+
+version="$1"
+if [ -z "$version" ]; then
+  echo "Usage: integration_test.sh <nodecg-io-version>"
+  exit 1
+fi
+
+dir=$(mktemp -d)
+
+echo "Test directory: $dir"
+function clean_test_directory {
+    echo "Cleaning test directory at $dir"
+    rm -rf $dir
+}
+trap clean_test_directory EXIT
+
+cd $dir
+git clone https://github.com/nodecg/nodecg.git --depth 1 .
+
+if [ "$version" == "development" ]; then
+    nodecg-io install --nodecg-io-version $version --docs
+else
+    nodecg-io install --nodecg-io-version $version --all-services
+fi
+
+nodecg-io uninstall
+


### PR DESCRIPTION
Adds a test to CI that ensures that the CLI can install any nodecg-io version with all services on windows and linux with the latest node.js versions. 
For all production versions it also ensures that the CLI can generate a bundle that depends on all services and compiles successfully when using TypeScript.

The test currently fails because of https://github.com/codeoverflow-org/nodecg-io/issues/453. This PR will be merged after that issue has been fixed.