### PR TITLE
Increase wait time between inputs in integration tests

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -34,7 +34,7 @@ else
     input="test\\n\n\\n\\na\\n\\n\\n\\n"
     # We add a sleep of 500ms between each line so that stdin pauses and inquirer 
     # thinks the user is done, reads and processes the input instead of assuming multi-line input.
-    echo -en "$input" | while read -r line; do echo "$line"; sleep 1; done | nodecg-io generate
+    echo -en "$input" | while read -r line; do echo "$line"; sleep 1.5; done | nodecg-io generate
 fi
 
 nodecg-io uninstall


### PR DESCRIPTION
Some CI runs failed because the timeout of one second was too small.
This PR raises the sleep time to 1.5 seconds to (hopefully) fix this in the future.
Example run: https://github.com/codeoverflow-org/nodecg-io-cli/runs/5167944843?check_suite_focus=true