### PR TITLE
Use windows-2019 instead of windows-latest in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019]
         node: [12, 14, 16, 17]
 
     runs-on: ${{ matrix.os }}
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019]
         version: ['0.1', '0.2', 'development']
         node: [14, 16]
 


### PR DESCRIPTION
`windows-latest` was recently switched to be an alias for `windows-2022` instead of `windows-2019`. This causes the recent build failures because node-gyp doesn't work properly with Visual Studio 2022 yet. This PR changes it back to `windows-2019` to fix build failures till node-gyp fully supports Visual Studio 2022.