### PR TITLE
chore: Use `npm i --omit=dev` instead of `npm i --prod`

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -8,4 +8,4 @@ npm link
 # Get nodecg so you can test the cli using this installation
 [ ! -d "nodecg" ] && git clone https://github.com/nodecg/nodecg.git 
 
-cd nodecg && npm i --prod
+cd nodecg && npm i --omit=dev

--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -172,12 +172,12 @@ export async function downloadNpmPackage(pkg: NpmPackage, nodecgIODir: string): 
 }
 
 /**
- * Installs npm production dependencies in the passed path by running npm install --prod in the directory.
+ * Installs npm production dependencies in the passed path by running npm install --omit=dev in the directory.
  * @param path the path where a package.json is present
  * @param onlyProd whether to only install production dependencies or also devDependencies.
  */
 export async function runNpmInstall(path: string, onlyProd: boolean): Promise<void> {
-    const prodArg = onlyProd ? ["--prod"] : [];
+    const prodArg = onlyProd ? ["--omit=dev"] : [];
     await executeCommand("npm", ["install", ...prodArg], path);
 }
 

--- a/test/utils/npm/pkgManagement.ts
+++ b/test/utils/npm/pkgManagement.ts
@@ -19,12 +19,12 @@ const execMock = jest.spyOn(fsUtils, "executeCommand").mockResolvedValue();
 afterEach(() => execMock.mockClear());
 
 describe("runNpmInstall", () => {
-    test("should execute npm install --prod when installing prod only", async () => {
+    test("should execute npm install --omit=dev when installing only production dependencies", async () => {
         await runNpmInstall(fsRoot, true);
         expect(execMock).toHaveBeenCalled();
         expect(execMock.mock.calls[0]?.[0]).toBe(npmCommand);
         expect(execMock.mock.calls[0]?.[1]?.[0]).toBe("install");
-        expect(execMock.mock.calls[0]?.[1]?.[1]).toBe("--prod");
+        expect(execMock.mock.calls[0]?.[1]?.[1]).toBe("--omit=dev");
         expect(execMock.mock.calls[0]?.[2]).toBe(fsRoot);
     });
 


### PR DESCRIPTION
The `--production` flag for `npm install` has been deprecated in a recent npm release. Instead of `--prod` the documentation says we should use `--omit=dev` which this PR does: https://docs.npmjs.com/cli/v8/using-npm/config#production
This flag already exists in npm v7 so people running that version can still use the cli just fine.