### PR TITLE
Support for NodeCG v2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,13 +6,23 @@
         "dockerfile": "Dockerfile"
     },
 
-    // Set *default* container specific settings.json values on container create.
-    "settings": {
-        "terminal.integrated.shell.linux": "/bin/zsh"
+    "customizations": {
+        "vscode": {
+            "extensions": ["dbaeumer.vscode-eslint", "Orta.vscode-jest"],
+            "settings": {
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "bash",
+                        "icon": "terminal-bash"
+                    },
+                    "zsh": {
+                        "path": "zsh"
+                    }
+                },
+                "terminal.integrated.defaultProfile.linux": "zsh"
+            }
+        }
     },
-
-    // Add the IDs of extensions you want installed when the container is created.
-    "extensions": ["dbaeumer.vscode-eslint"],
 
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // 9090 is the default nodecg port if you have setup a nodecg install using the install command and want to test it

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -8,4 +8,4 @@ npm link
 # Get nodecg so you can test the cli using this installation
 [ ! -d "nodecg" ] && git clone https://github.com/nodecg/nodecg.git 
 
-cd nodecg && npm i --omit=dev
+cd nodecg && npm i && npm run build

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -22,7 +22,14 @@ function clean_test_directory {
 trap clean_test_directory EXIT
 
 cd $dir
-git clone https://github.com/nodecg/nodecg.git --depth 1 .
+
+# Download NodeCG
+if [ "$version" == "0.1" ] || [ "$version" == "0.2" ]; then
+    # if version is 0.1 or 0.2 then switch back to NodeCG v1
+    git clone https://github.com/nodecg/nodecg.git --depth 1 --branch legacy-1.x .
+else
+    git clone https://github.com/nodecg/nodecg.git --depth 1 .
+fi
 
 if [ "$version" == "development" ]; then
     nodecg-io install --nodecg-io-version $version --docs

--- a/src/generate/packageJson.ts
+++ b/src/generate/packageJson.ts
@@ -5,6 +5,7 @@ import { genNodeCGDashboardConfig, genNodeCGGraphicConfig } from "./panel";
 import { SemVer } from "semver";
 import { writeBundleFile } from "./utils";
 import { Installation } from "../utils/installation";
+import { determineNodeCGImportPath } from "./extension";
 
 // Loaction where the development tarballs are hosted.
 export const developmentPublishRootUrl = "https://codeoverflow-org.github.io/nodecg-io-publish/";
@@ -54,7 +55,7 @@ async function genDependencies(opts: GenerationOptions, serviceDeps: Dependency[
 
     if (opts.language === "typescript") {
         // For typescript we need core, all services (for typings) and special packages like ts itself or node typings.
-        const deps = [core, ...serviceDeps, ...(await genTypeScriptDependencies(opts))];
+        const deps = [core, ...serviceDeps, ...(await genTypeScriptDependencies(opts, install))];
         deps.sort();
         return deps;
     } else {
@@ -66,14 +67,22 @@ async function genDependencies(opts: GenerationOptions, serviceDeps: Dependency[
 /**
  * Generates all extra dependencies that are needed when having a bundle in TS. Meaning typescript itself, nodecg for typings
  * and types for node.
- * @param nodecgDir the directory in which nodecg is installed. Used to get nodecg version which will be used by nodecg dependency.
+ * @return the dependencies that are needed for a TS bundle.
  */
-async function genTypeScriptDependencies(opts: GenerationOptions): Promise<Dependency[]> {
-    logger.debug(
-        `Fetching latest ${opts.nodeCGTypingsPackage}, nodecg-io-tsconfig, typescript and @types/node versions...`,
-    );
-    const [nodecgVersion, latestTsConfig, latestTypeScript, latestNodeTypes] = await Promise.all([
-        getLatestPackageVersion(opts.nodeCGTypingsPackage),
+async function genTypeScriptDependencies(opts: GenerationOptions, install: Installation): Promise<Dependency[]> {
+    const nodecgTypingPackage = determineNodeCGImportPath(opts, install).replace("/types/server", "");
+    if (!nodecgTypingPackage) {
+        throw new Error("Could not determine nodecg typing package");
+    }
+
+    let nodecgTypingVersion = opts.nodeCGVersion;
+    if (nodecgTypingPackage === "nodecg-types") {
+        logger.debug(`Fetching latest nodecg-types version...`);
+        nodecgTypingVersion = await getLatestPackageVersion("nodecg-types");
+    }
+
+    logger.debug(`Fetching latest nodecg-io-tsconfig, typescript and @types/node versions...`);
+    const [latestTsConfig, latestTypeScript, latestNodeTypes] = await Promise.all([
         getLatestPackageVersion("nodecg-io-tsconfig"),
         getLatestPackageVersion("typescript"),
         getLatestPackageVersion("@types/node"),
@@ -81,7 +90,7 @@ async function genTypeScriptDependencies(opts: GenerationOptions): Promise<Depen
 
     return [
         ["@types/node", `^${latestNodeTypes}`],
-        [opts.nodeCGTypingsPackage, `^${nodecgVersion}`],
+        [nodecgTypingPackage, `^${nodecgTypingVersion}`],
         ["nodecg-io-tsconfig", `^${latestTsConfig}`],
         ["typescript", `^${latestTypeScript}`],
     ];

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -91,6 +91,7 @@ async function install(opts: InstallCommandOptions): Promise<void> {
             requestedInstall,
             currentInstall && !currentInstall.dev ? currentInstall : undefined,
             nodecgIODir,
+            nodecgDir,
         );
     }
 

--- a/test/generate/opts.util.ts
+++ b/test/generate/opts.util.ts
@@ -1,6 +1,6 @@
-import { computeGenOptsFields, GenerationOptions, PromptedGenerationOptions } from "../../src/generate/prompt";
+import { GenerationOptions, PromptedGenerationOptions } from "../../src/generate/prompt";
 import * as path from "path";
-import { fsRoot, twitchChatPkg, validProdInstall } from "../test.util";
+import { corePkg, fsRoot, twitchChatPkg } from "../test.util";
 import { SemVer } from "semver";
 
 export const defaultOptsPrompt: PromptedGenerationOptions = {
@@ -14,5 +14,11 @@ export const defaultOptsPrompt: PromptedGenerationOptions = {
     dashboard: false,
 };
 
-export const defaultOpts = computeGenOptsFields(defaultOptsPrompt, validProdInstall, validProdInstall.packages);
+export const defaultOpts: GenerationOptions = {
+    ...defaultOptsPrompt,
+    servicePackages: [twitchChatPkg],
+    corePackage: corePkg,
+    nodeCGVersion: new SemVer("2.0.0"),
+    bundlePath: path.join(fsRoot, "bundles", "test-bundle"),
+};
 export const jsOpts: GenerationOptions = { ...defaultOpts, language: "javascript" };


### PR DESCRIPTION
- [x] Support for generating bundles with the new typings (fixes integration tests for 0.2)
- [x] Only allow installing nodecg-io versions that are supported by the currently used NodeCG version (fixes integration tests for 0.1 as it requires NodeCG v1)
- [x] Update NodeCG compatible range depending on installed nodecg-io version